### PR TITLE
registerAudioNode周りデバッグ

### DIFF
--- a/src/components/NodeEditor.tsx
+++ b/src/components/NodeEditor.tsx
@@ -24,9 +24,10 @@ import NodeLFO from '../modules/NodeLFO';
 import NodeOscilloscope from '../modules/NodeOscilloscope';
 import TemplateSelector, { FlowTemplate, presetTemplates } from '../modules/TemplateSelector';
 import { audioNodeManager } from '../utils/AudioNodeManager';
+import ButtonTestVCOModulation from '@/modules/ButtonTestVCOModulation';
 //import ButtonTestVCOModulation from '@/modules/ButtonTestVCOModulation';
 
-const debug = false;
+const debug = true;
 
 // ノードの種類を定義
 const nodeTypes: NodeTypes = {
@@ -183,7 +184,10 @@ const NodeEditor = () => {
           </Button>
         </Stack>
         <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 1 }}>
-          {debug && (
+          <TemplateSelector onApplyTemplate={handleApplyTemplate} />
+        </Box>
+        {debug && (
+          <Box sx={{ display: 'flex', gap: 1, alignItems: 'center', mt: 1 }}>
             <Button
               variant="contained"
               color="warning"
@@ -194,10 +198,9 @@ const NodeEditor = () => {
             >
               Debug Nodes/Edges
             </Button>
-          )}
-
-          <TemplateSelector onApplyTemplate={handleApplyTemplate} />
-        </Box>
+            <ButtonTestVCOModulation />
+          </Box>
+        )}
       </Box>
       <Box sx={{ flex: 1, position: 'relative', overflow: 'hidden' }}>
         <ReactFlow

--- a/src/components/NodeEditor.tsx
+++ b/src/components/NodeEditor.tsx
@@ -27,7 +27,7 @@ import { audioNodeManager } from '../utils/AudioNodeManager';
 import ButtonTestVCOModulation from '@/modules/ButtonTestVCOModulation';
 //import ButtonTestVCOModulation from '@/modules/ButtonTestVCOModulation';
 
-const debug = true;
+const debug = false;
 
 // ノードの種類を定義
 const nodeTypes: NodeTypes = {

--- a/src/components/NodeEditor.tsx
+++ b/src/components/NodeEditor.tsx
@@ -52,10 +52,13 @@ const NodeEditor = () => {
   const [panOnDrag, setPanOnDrag] = useState(true);
 
   // オーディオノード登録用のメモ化された関数
-  const registerAudioNode = useCallback((nodeId: string, audioNode: Tone.ToneAudioNode) => {
-    console.log('registerAudioNode', nodeId);
-    audioNodeManager.registerAudioNode(nodeId, audioNode, edges);
-  }, []);
+  const registerAudioNode = useCallback(
+    (nodeId: string, audioNode: Tone.ToneAudioNode) => {
+      console.log('registerAudioNode', nodeId);
+      audioNodeManager.registerAudioNode(nodeId, audioNode, edges);
+    },
+    [edges]
+  );
 
   useEffect(() => {
     console.log('edges', edges);

--- a/src/modules/NodeLFO.tsx
+++ b/src/modules/NodeLFO.tsx
@@ -22,7 +22,6 @@ interface NodeLFOProps {
 
 const NodeLFO = ({ data, id }: NodeLFOProps) => {
   const lfo = useRef<Tone.LFO | null>(null);
-  const outputSignal = useRef<Tone.Signal | null>(null);
 
   // オーディオノードの生成・破棄
   useEffect(() => {
@@ -30,13 +29,9 @@ const NodeLFO = ({ data, id }: NodeLFOProps) => {
       frequency: data.frequency || 1,
       type: data.type || 'sine',
       amplitude: data.amplitude || 1,
+      min: 0,
+      max: 1,
     });
-
-    // 出力用のSignalを作成
-    outputSignal.current = new Tone.Signal(0);
-
-    // LFOの出力をSignalに接続
-    lfo.current.connect(outputSignal.current);
 
     // LFOを開始
     lfo.current.start();
@@ -44,14 +39,13 @@ const NodeLFO = ({ data, id }: NodeLFOProps) => {
     return () => {
       lfo.current?.stop();
       lfo.current?.dispose();
-      outputSignal.current?.dispose();
     };
   }, [id, data.frequency, data.type, data.amplitude]);
 
   // オーディオノードの登録
   useEffect(() => {
-    if (outputSignal.current) {
-      data.registerAudioNode(id, outputSignal.current);
+    if (lfo.current) {
+      data.registerAudioNode(id, lfo.current);
     }
   }, [id, data.registerAudioNode, data.edges]);
 
@@ -74,7 +68,7 @@ const NodeLFO = ({ data, id }: NodeLFOProps) => {
   }, []);
 
   return (
-    <NodeBox id={id} label={data.label}>
+    <NodeBox id={id} label={data.label} hasInputHandle={false}>
       <Box sx={{ mt: 2 }}>
         <CustomSlider
           label="Frequency"

--- a/src/modules/NodeOscilloscope.tsx
+++ b/src/modules/NodeOscilloscope.tsx
@@ -20,18 +20,12 @@ const NodeOscilloscope = ({ data, id }: NodeOscilloscopeProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const analyserRef = useRef<Tone.Analyser | null>(null);
   const animationFrameRef = useRef<number | undefined>(undefined);
-  const gainNodeRef = useRef<Tone.Gain | null>(null);
 
   // オーディオノードの生成・破棄
   useEffect(() => {
-    // アナライザーの設定
     analyserRef.current = new Tone.Analyser('waveform', data.size || 1024);
 
-    // ゲインノードの作成（信号をそのまま通過させる）
-    gainNodeRef.current = new Tone.Gain(1);
-
-    // アナライザーとゲインノードを接続
-    gainNodeRef.current.connect(analyserRef.current);
+    data.registerAudioNode(id, analyserRef.current);
 
     const draw = () => {
       const canvas = canvasRef.current;
@@ -41,51 +35,26 @@ const NodeOscilloscope = ({ data, id }: NodeOscilloscopeProps) => {
         const ctx = canvas.getContext('2d');
         if (ctx) {
           const values = analyser.getValue() as Float32Array;
-          const width = canvas.width;
-          const height = canvas.height;
 
           // キャンバスをクリア
-          ctx.clearRect(0, 0, width, height);
+          ctx.clearRect(0, 0, canvas.width, canvas.height);
 
-          // 背景を描画
-          ctx.fillStyle = '#f5f5f5';
-          ctx.fillRect(0, 0, width, height);
-
-          // グリッドを描画
-          ctx.strokeStyle = '#e0e0e0';
-          ctx.lineWidth = 1;
-          ctx.beginPath();
-          for (let i = 0; i < width; i += 20) {
-            ctx.moveTo(i, 0);
-            ctx.lineTo(i, height);
-          }
-          for (let i = 0; i < height; i += 20) {
-            ctx.moveTo(0, i);
-            ctx.lineTo(width, i);
-          }
-          ctx.stroke();
-
-          // 波形を描画
+          // 波形の描画
           ctx.beginPath();
           ctx.strokeStyle = '#1976d2';
           ctx.lineWidth = 2;
 
-          const sliceWidth = width / values.length;
-          let x = 0;
-
-          for (let i = 0; i < values.length; i++) {
-            const y = ((values[i] + 1) / 2) * height;
+          values.forEach((value: number, i: number) => {
+            const x = (i / values.length) * canvas.width;
+            const y = ((value + 1) / 2) * canvas.height;
 
             if (i === 0) {
               ctx.moveTo(x, y);
             } else {
               ctx.lineTo(x, y);
             }
+          });
 
-            x += sliceWidth;
-          }
-
-          ctx.lineTo(width, height / 2);
           ctx.stroke();
         }
       }
@@ -102,33 +71,20 @@ const NodeOscilloscope = ({ data, id }: NodeOscilloscopeProps) => {
       if (analyserRef.current) {
         analyserRef.current.dispose();
       }
-      if (gainNodeRef.current) {
-        gainNodeRef.current.dispose();
-      }
     };
-  }, [id, data.size]);
+  }, [id, data.size, data.registerAudioNode]);
 
   // オーディオノードの登録
   useEffect(() => {
-    if (gainNodeRef.current) {
-      data.registerAudioNode(id, gainNodeRef.current);
+    if (analyserRef.current) {
+      //data.registerAudioNode(id, analyserRef.current);
     }
   }, [id, data.registerAudioNode, data.edges]);
 
   return (
-    <NodeBox id={id} label={data.label} hasInputHandle={true} hasOutputHandle={true}>
-      <Box sx={{ mt: 2, width: '100%', height: '100px', position: 'relative' }}>
-        <canvas
-          ref={canvasRef}
-          width={200}
-          height={100}
-          style={{
-            width: '100%',
-            height: '100%',
-            border: '1px solid #ccc',
-            borderRadius: '4px',
-          }}
-        />
+    <NodeBox id={id} label={data.label} hasOutputHandle={false}>
+      <Box sx={{ mt: 2 }}>
+        <canvas ref={canvasRef} width={200} height={100} style={{ border: '1px solid #ccc' }} />
       </Box>
     </NodeBox>
   );

--- a/src/modules/NodeOscilloscope.tsx
+++ b/src/modules/NodeOscilloscope.tsx
@@ -20,10 +20,18 @@ const NodeOscilloscope = ({ data, id }: NodeOscilloscopeProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const analyserRef = useRef<Tone.Analyser | null>(null);
   const animationFrameRef = useRef<number | undefined>(undefined);
+  const gainNodeRef = useRef<Tone.Gain | null>(null);
 
   // オーディオノードの生成・破棄
   useEffect(() => {
+    // アナライザーの設定
     analyserRef.current = new Tone.Analyser('waveform', data.size || 1024);
+
+    // ゲインノードの作成（信号をそのまま通過させる）
+    gainNodeRef.current = new Tone.Gain(1);
+
+    // アナライザーとゲインノードを接続
+    gainNodeRef.current.connect(analyserRef.current);
 
     const draw = () => {
       const canvas = canvasRef.current;
@@ -33,26 +41,51 @@ const NodeOscilloscope = ({ data, id }: NodeOscilloscopeProps) => {
         const ctx = canvas.getContext('2d');
         if (ctx) {
           const values = analyser.getValue() as Float32Array;
+          const width = canvas.width;
+          const height = canvas.height;
 
           // キャンバスをクリア
-          ctx.clearRect(0, 0, canvas.width, canvas.height);
+          ctx.clearRect(0, 0, width, height);
 
-          // 波形の描画
+          // 背景を描画
+          ctx.fillStyle = '#f5f5f5';
+          ctx.fillRect(0, 0, width, height);
+
+          // グリッドを描画
+          ctx.strokeStyle = '#e0e0e0';
+          ctx.lineWidth = 1;
+          ctx.beginPath();
+          for (let i = 0; i < width; i += 20) {
+            ctx.moveTo(i, 0);
+            ctx.lineTo(i, height);
+          }
+          for (let i = 0; i < height; i += 20) {
+            ctx.moveTo(0, i);
+            ctx.lineTo(width, i);
+          }
+          ctx.stroke();
+
+          // 波形を描画
           ctx.beginPath();
           ctx.strokeStyle = '#1976d2';
           ctx.lineWidth = 2;
 
-          values.forEach((value: number, i: number) => {
-            const x = (i / values.length) * canvas.width;
-            const y = ((value + 1) / 2) * canvas.height;
+          const sliceWidth = width / values.length;
+          let x = 0;
+
+          for (let i = 0; i < values.length; i++) {
+            const y = ((values[i] + 1) / 2) * height;
 
             if (i === 0) {
               ctx.moveTo(x, y);
             } else {
               ctx.lineTo(x, y);
             }
-          });
 
+            x += sliceWidth;
+          }
+
+          ctx.lineTo(width, height / 2);
           ctx.stroke();
         }
       }
@@ -69,20 +102,33 @@ const NodeOscilloscope = ({ data, id }: NodeOscilloscopeProps) => {
       if (analyserRef.current) {
         analyserRef.current.dispose();
       }
+      if (gainNodeRef.current) {
+        gainNodeRef.current.dispose();
+      }
     };
   }, [id, data.size]);
 
   // オーディオノードの登録
   useEffect(() => {
-    if (analyserRef.current) {
-      data.registerAudioNode(id, analyserRef.current);
+    if (gainNodeRef.current) {
+      data.registerAudioNode(id, gainNodeRef.current);
     }
   }, [id, data.registerAudioNode, data.edges]);
 
   return (
-    <NodeBox id={id} label={data.label}>
-      <Box sx={{ mt: 2 }}>
-        <canvas ref={canvasRef} width={200} height={100} style={{ border: '1px solid #ccc' }} />
+    <NodeBox id={id} label={data.label} hasInputHandle={true} hasOutputHandle={true}>
+      <Box sx={{ mt: 2, width: '100%', height: '100px', position: 'relative' }}>
+        <canvas
+          ref={canvasRef}
+          width={200}
+          height={100}
+          style={{
+            width: '100%',
+            height: '100%',
+            border: '1px solid #ccc',
+            borderRadius: '4px',
+          }}
+        />
       </Box>
     </NodeBox>
   );

--- a/src/modules/TemplateSelector.tsx
+++ b/src/modules/TemplateSelector.tsx
@@ -18,13 +18,19 @@ export type FlowTemplate = {
  */
 export const presetTemplates: FlowTemplate[] = [
   {
-    name: '基本VCO→出力',
+    name: 'LFO->VCO->OUT',
     nodes: [
       {
         id: 'vco1',
         type: 'vco',
-        position: { x: 10, y: 10 },
+        position: { x: 300, y: 200 },
         data: { label: 'VCO', frequency: 440, type: 'sine', registerAudioNode: null },
+      },
+      {
+        id: 'lfo1',
+        type: 'lfo',
+        position: { x: 10, y: 100 },
+        data: { label: 'LFO', frequency: 1, type: 'sine', registerAudioNode: null },
       },
       {
         id: 'toDestination',

--- a/src/utils/AudioNodeManager.ts
+++ b/src/utils/AudioNodeManager.ts
@@ -55,17 +55,16 @@ export class AudioNodeManager {
    * @param edges - 現在のエッジ情報
    */
   registerAudioNode(nodeId: string, audioNode: Tone.ToneAudioNode, edges: Edge[]): void {
-    console.log('registerAudioNode', nodeId, audioNode, edges);
+    //console.log('registerAudioNode', nodeId, audioNode, edges);
 
     // 既存の接続を解除
     const existingNode = this.audioNodes.get(nodeId);
     if (existingNode) {
-      console.log('Disconnecting existing node:', nodeId);
-      existingNode.disconnect();
+      //console.log('Disconnecting existing node:', nodeId);
+      //existingNode.disconnect();
     }
 
     this.audioNodes.set(nodeId, audioNode);
-
     // このノードに接続している既存のエッジを探して再接続
     edges.forEach((edge) => {
       try {
@@ -98,15 +97,28 @@ export class AudioNodeManager {
             const toneType = targetNode.constructor.name;
             if (controlScales[toneType]?.[property]) {
               //  controlScales設定がある場合、Tone.Scaleを使用して接続
+
               const { min, max } = { ...controlScales[toneType][property] };
               const scale = new Tone.Scale(min, max);
               sourceNode.connect(scale);
               scale.connect(targetParam as Tone.InputNode);
-              console.log('targetNode', targetNode);
+
               console.log('sourceNode', sourceNode);
               console.log('targetParam', targetParam);
-              //sourceNode.connect(targetParam as Tone.InputNode);
               console.log('Connected with scale:', { min, max });
+
+              //console.log('sourceNode', sourceNode);
+              //sourceNode.connect(targetParam as Tone.InputNode);
+              /*
+              const lfo = new Tone.LFO({
+                min: 20,
+                max: 2000,
+                frequency: 2,
+                amplitude: 1,
+              });
+              lfo.start();
+              lfo.connect(targetParam as Tone.InputNode);
+              */
             } else {
               sourceNode.connect(targetParam as Tone.InputNode);
               console.log('Connected directly to parameter');

--- a/src/utils/AudioNodeManager.ts
+++ b/src/utils/AudioNodeManager.ts
@@ -92,6 +92,7 @@ export class AudioNodeManager {
 
         if (nodeType === 'control' && property && property in targetNode) {
           const targetParam = targetNode[property as keyof typeof targetNode];
+          console.log('targetParam', targetParam);
           if (targetParam !== undefined && typeof (targetParam as any).connect === 'function') {
             console.log('Connecting control parameter:', property);
             const toneType = targetNode.constructor.name;
@@ -101,6 +102,10 @@ export class AudioNodeManager {
               const scale = new Tone.Scale(min, max);
               sourceNode.connect(scale);
               scale.connect(targetParam as Tone.InputNode);
+              console.log('targetNode', targetNode);
+              console.log('sourceNode', sourceNode);
+              console.log('targetParam', targetParam);
+              //sourceNode.connect(targetParam as Tone.InputNode);
               console.log('Connected with scale:', { min, max });
             } else {
               sourceNode.connect(targetParam as Tone.InputNode);


### PR DESCRIPTION
* edgesの情報更新のタイミングでregisterAudioNodeの扱い修正
* audioNodeManagerの方でもedgesの情報を監視できるようにしたほうが良いのかな？
* registerAudioNodeのedgesの再接続処理はsource->targetのみに限定
* LFOとOscilloscopeのデバッグ（ちょっと古いバージョンに戻した）